### PR TITLE
Set Content-Type header to application/json

### DIFF
--- a/src/CortexPE/DiscordWebhookAPI/task/DiscordWebhookSendTask.php
+++ b/src/CortexPE/DiscordWebhookAPI/task/DiscordWebhookSendTask.php
@@ -52,6 +52,7 @@ class DiscordWebhookSendTask extends AsyncTask {
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($ch, CURLOPT_HTTPHEADER, ["Content-Type: application/json"]);
 		$this->setResult(curl_exec($ch));
 		curl_close($ch);
 	}


### PR DESCRIPTION
``Content-Type: application/json`` is a required header since recent changed otherwise you get the following error:
```json
{
    "code": 50006,
    "message": "Cannot send an empty message"
}
```