### PR TITLE
feature: Message->getAllowedMentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,14 @@ Now that the embed has been constructed and has a valid content, we will have to
 $msg->addEmbed($embed);
 ```
 
-You can even enable specific mentions, using the following statement: `Message->getAllowedMentions`. The only things you need are discord snowflakes/ids.
+You can even enable specific mentions, using the following statement: `Message->getAllowedMentions()`. The only things you need are discord snowflakes/ids.
+Be aware, if you call `Message->getAllowedMentions()` you will get a new instance of the `AllowedMentions` class, which will allowing all mentions passing through.
 ```php
-$msg->getAllowedMentions()->addUser($userId1, $userId2); // Only the two users corresponding with these two ids will be mentionend
+$msg->getAllowedMentions()->addUser($userId1, $userId2); // Only the two users corresponding with these two ids will be mentioned
 $msg->getAllowedMentions()->addRole($roleId1, $roleId2); // Now also all the people with $roleId1 and $roleId2 will be mentioned
 ```
 
-But if you want to supress every mention out of that message you can use following method.
+But if you want to suppress every mention out of that message you can use following method.
 ```php
 $msg->getAllowedMentions()->suppressAll();
 ```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $msg->getAllowedMentions()->addRole($roleId1, $roleId2); // Now also all the peo
 
 But if you want to supress every mention out of that message you can use following method.
 ```php
-$msg->getAllowedMentions()->supressAll();
+$msg->getAllowedMentions()->suppressAll();
 ```
 
 **That's all for the Basic Usage of the API. To learn more, You can explore it by reading the API's source code yourself (the code is simple and explanatory) or by using your favorite IDE to index it yourself. :3**
@@ -83,6 +83,7 @@ $msg = new Message();
 $msg->setUsername("USERNAME");
 $msg->setAvatarURL("https://cortexpe.xyz/utils/kitsu.png");
 $msg->setContent("INSERT TEXT HERE");
+$msg->suppressAll();
 
 // Create an embed object with #FF0000 (RED) as the embed's color and "EMBED 1" as the title
 $embed = new Embed();

--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ Now that the embed has been constructed and has a valid content, we will have to
 ```php
 $msg->addEmbed($embed);
 ```
+
+You can even enable specific mentions, using the following statement: `Message->getAllowedMentions`. The only things you need are discord snowflakes/ids.
+```php
+$msg->getAllowedMentions()->addUser($userId1, $userId2); // Only the two users corresponding with these two ids will be mentionend
+$msg->getAllowedMentions()->addRole($roleId1, $roleId2); // Now also all the people with $roleId1 and $roleId2 will be mentioned
+```
+
+But if you want to supress every mention out of that message you can use following method.
+```php
+$msg->getAllowedMentions()->supressAll();
+```
+
 **That's all for the Basic Usage of the API. To learn more, You can explore it by reading the API's source code yourself (the code is simple and explanatory) or by using your favorite IDE to index it yourself. :3**
 # Sample Code used to test this API earlier:
 ```php

--- a/src/CortexPE/DiscordWebhookAPI/AllowedMentions.php
+++ b/src/CortexPE/DiscordWebhookAPI/AllowedMentions.php
@@ -31,8 +31,7 @@ namespace CortexPE\DiscordWebhookAPI;
 use function count;
 use function in_array;
 
-class AllowedMentions implements \JsonSerializable
-{
+class AllowedMentions implements \JsonSerializable {
 	/** @var bool */
 	private $parseUsers = true, $parseRoles = true, $mentionEveryone = true, $suppressAll = false;
 
@@ -88,8 +87,7 @@ class AllowedMentions implements \JsonSerializable
 		$this->suppressAll = true;
 	}
 
-	public function jsonSerialize(): array
-	{
+	public function jsonSerialize(): array {
 		if ($this->suppressAll) {
 			return [
 				"parse" => []

--- a/src/CortexPE/DiscordWebhookAPI/AllowedMentions.php
+++ b/src/CortexPE/DiscordWebhookAPI/AllowedMentions.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ *
+ *  _____      __    _   ___ ___
+ * |   \ \    / /__ /_\ | _ \_ _|
+ * | |) \ \/\/ /___/ _ \|  _/| |
+ * |___/ \_/\_/   /_/ \_\_| |___|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Written by @CortexPE <https://CortexPE.xyz>
+ * Intended for use on SynicadeNetwork <https://synicade.com>
+ */
+
+declare(strict_types = 1);
+
+namespace CortexPE\DiscordWebhookAPI;
+
+use function count;
+use function in_array;
+
+class AllowedMentions implements \JsonSerializable
+{
+	/** @var bool */
+	private $parseUsers = true, $parseRoles = true, $mentionEveryone = true, $suppressAll = false;
+
+	/** @var array */
+	private $roles = [];
+
+	/** @var array */
+	private $users = [];
+
+	/**
+	 * If following role is given into the messages content, every user of it will be mentioned
+	 * @param string ...$roleID
+	 */
+	public function addRole(string ...$roleID): void {
+		foreach ($roleID as $item) {
+			if (in_array($item, $this->roles, true)) {
+				continue;
+			}
+
+			$this->roles[] = $item;
+		}
+		$this->parseRoles = false;
+	}
+
+	/**
+	 * If following user is given into the messages content, the user will be mentioned
+	 * @param string ...$userID
+	 */
+	public function addUser(string ...$userID): void {
+		foreach ($userID as $item) {
+			if (in_array($item, $this->users, true)) {
+				continue;
+			}
+
+			$this->users[] = $item;
+		}
+
+		$this->parseUsers = false;
+	}
+
+	/**
+	 * If the message content has whether everyone or here and $mention is set to false, the users won't be mentioned
+	 * @param bool $mention
+	 */
+	public function mentionEveryone(bool $mention): void {
+		$this->mentionEveryone = $mention;
+	}
+
+	/**
+	 * If this function is called no mention will be getting showed for anyone
+	 */
+	public function suppressAll(): void {
+		$this->suppressAll = true;
+	}
+
+	public function jsonSerialize(): array
+	{
+		if ($this->suppressAll) {
+			return [
+				"parse" => []
+			];
+		}
+
+		$data = ["parse" => []];
+		if ($this->mentionEveryone) {
+			$data["parse"][] = "everyone";
+		}
+
+		if (count($this->users) !== 0) {
+			$data["users"] = $this->users;
+		} else if ($this->parseUsers) {
+			$data["parse"][] = "users";
+		}
+
+		if (count($this->roles) !== 0) {
+			$data["roles"] = $this->roles;
+		} else if ($this->parseRoles) {
+			$data["parse"][] = "roles";
+		}
+
+		return $data;
+	}
+}

--- a/src/CortexPE/DiscordWebhookAPI/Message.php
+++ b/src/CortexPE/DiscordWebhookAPI/Message.php
@@ -67,8 +67,12 @@ class Message implements \JsonSerializable {
 		$this->data["tts"] = $ttsEnabled;
 	}
 	
-	public function setAllowedMentions(bool $roles = true, bool $users = true, bool $everyone = true): void {
-		$this->data["allowed_mentions"] = ["roles" => $roles, "users" => $users, "everyone" => $everyone];
+	public function getAllowedMentions(): AllowedMentions {
+		if (array_key_exists("allowed_mentions", $this->data)) {
+			return $this->data["allowed_mentions"];
+		}
+
+		return $this->data["allowed_mentions"] = new AllowedMentions();
 	}
 
 	public function jsonSerialize(){

--- a/src/CortexPE/DiscordWebhookAPI/Message.php
+++ b/src/CortexPE/DiscordWebhookAPI/Message.php
@@ -66,6 +66,10 @@ class Message implements \JsonSerializable {
 	public function setTextToSpeech(bool $ttsEnabled):void{
 		$this->data["tts"] = $ttsEnabled;
 	}
+	
+	public function setAllowedMentions(bool $roles = true, bool $users = true, bool $everyone = true): void {
+		$this->data["allowed_mentions"] = ["roles" => $roles, "users" => $users, "everyone" => $everyone];
+	}
 
 	public function jsonSerialize(){
 		return $this->data;


### PR DESCRIPTION
This function adds the allowed_mentions field from the Execute Webhook request (Message->setAllowedMentions)
The function takes 3 parameters - Roles, Users and Everyone and all of them are set by default to false
Resources: 
- https://discord.com/developers/docs/resources/webhook
- https://discord.com/developers/docs/resources/channel#allowed-mentions-object